### PR TITLE
feat: Add falcon-based node to store POSTed image

### DIFF
--- a/nodes/one/node.py
+++ b/nodes/one/node.py
@@ -1,0 +1,6 @@
+import falcon
+from resources import Storage
+
+api = falcon.API()
+
+api.add_route('/storage/{filename}', Storage())

--- a/nodes/one/resources.py
+++ b/nodes/one/resources.py
@@ -1,0 +1,13 @@
+import falcon
+
+
+class Storage(object):
+
+    # Handle data in POST requests
+    def on_post(self, req, resp, filename):
+        if "/" in filename:
+            resp.status = falcon.HTTP_400
+        content = req.stream.read()
+        with open(filename, 'wb') as fw:
+            fw.write(content)
+        print("[+] File written")

--- a/server/app.py
+++ b/server/app.py
@@ -30,7 +30,7 @@ app = Flask(__name__)
 app.config['SECRET_KEY'] = os.urandom(11)
 app.config['UPLOAD_FOLDER'] = "storage"
 
-BROKER_URL = "http://localhost:6000/storage"
+BROKER_URL = "http://localhost:8000/storage"
 
 
 @app.route('/', methods=['GET', 'POST'])


### PR DESCRIPTION
This was a test done by uploading an image to the root server, and upload and save it in the `nodes/one` directory. This simulated that image was stored in the node one successfully.

However, there's still a need for code to manage all such nodes, to be done in commits to follow.